### PR TITLE
fix: build fix for forked branch PRs where git fetch is failing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: ${{ github.event.pull_request.commits }}
 


### PR DESCRIPTION
The ref parameter is using  `github.event.pull_request.head.ref`, which contains the branch name feat/tenant-support. However, the git fetch command is appending a wildcard pattern (feat/tenant-support*) that doesn't match the actual branch reference, causing the fetch to fail